### PR TITLE
Fix resume preview display in Scout and ApplicantManagement pages

### DIFF
--- a/src/main/webapp/ui/common/ResumePreviewPopup.xml
+++ b/src/main/webapp/ui/common/ResumePreviewPopup.xml
@@ -1,0 +1,525 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:w2="http://www.inswave.com/websquare"
+    xmlns:xf="http://www.w3.org/2002/xforms">
+    
+    <head meta_screenName="이력서 PDF 미리보기 팝업">
+        <w2:type>COMPONENT</w2:type>
+        <w2:buildDate />
+        <w2:MSA />
+        <xf:model>
+            <w2:dataCollection baseNode="map">
+                <!-- 이력서 정보 -->
+                <w2:dataMap baseNode="map" id="dma_resumeInfo">
+                    <w2:keyInfo>
+                        <w2:key id="result" name="결과" dataType="text"></w2:key>
+                        <w2:key id="hasResume" name="이력서 존재 여부" dataType="boolean"></w2:key>
+                        <w2:key id="resumeFileName" name="이력서 파일명" dataType="text"></w2:key>
+                        <w2:key id="displayName" name="표시 파일명" dataType="text"></w2:key>
+                        <w2:key id="viewUrl" name="조회 URL" dataType="text"></w2:key>
+                        <w2:key id="message" name="메시지" dataType="text"></w2:key>
+                        <w2:key id="accountId" name="계정 ID" dataType="text"></w2:key>
+                        <w2:key id="userName" name="사용자명" dataType="text"></w2:key>
+                    </w2:keyInfo>
+                </w2:dataMap>
+            </w2:dataCollection>
+            
+            <!-- 이력서 정보 조회 submission -->
+            <xf:submission id="sbm_getResumeInfo" action="/InsWebApp/USGetResumeInfo.pwkjson" method="get" mediatype="application/json"
+                ref="" target="" encoding="UTF-8" instance="" replace="" errorHandler=""
+                customHandler="" mode="asynchronous" processMsg="이력서 정보 조회중" ev:submitdone="scwin.sbm_getResumeInfo_submitdone" ev:submiterror="scwin.sbm_getResumeInfo_submiterror" abortTrigger="">
+            </xf:submission>
+        </xf:model>
+        
+        <style type="text/css"><![CDATA[
+            /* 팝업 컨테이너 */
+            .popup-container {
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+                background-color: #fff;
+                border-radius: 8px;
+                overflow: hidden;
+            }
+            
+            /* 헤더 영역 */
+            .popup-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 15px 20px;
+                background-color: #f8f9fa;
+                border-bottom: 1px solid #e9ecef;
+            }
+            
+            .popup-title {
+                font-size: 16px;
+                font-weight: bold;
+                color: #333;
+                margin: 0;
+                flex: 1;
+            }
+            
+            .popup-buttons {
+                display: flex;
+                gap: 8px;
+            }
+            
+            .popup-btn {
+                padding: 6px 12px;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+                font-size: 12px;
+                font-weight: 500;
+                transition: background-color 0.2s;
+            }
+            
+            .popup-btn.btn-new-window {
+                background-color: #007bff;
+                color: white;
+            }
+            
+            .popup-btn.btn-new-window:hover {
+                background-color: #0056b3;
+            }
+            
+            .popup-btn.btn-new-tab {
+                background-color: #28a745;
+                color: white;
+            }
+            
+            .popup-btn.btn-new-tab:hover {
+                background-color: #1e7e34;
+            }
+            
+            .popup-btn.btn-close {
+                background-color: #6c757d;
+                color: white;
+            }
+            
+            .popup-btn.btn-close:hover {
+                background-color: #545b62;
+            }
+            
+            /* PDF 뷰어 영역 */
+            .pdf-viewer-area {
+                flex: 1;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                padding: 20px;
+                background-color: #f8f9fa;
+            }
+            
+            .pdf-iframe {
+                width: 100%;
+                height: 100%;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                background-color: white;
+            }
+            
+            /* 메시지 영역 */
+            .message-area {
+                text-align: center;
+                padding: 40px 20px;
+                color: #6c757d;
+            }
+            
+            .message-title {
+                font-size: 18px;
+                font-weight: bold;
+                margin-bottom: 10px;
+                color: #495057;
+            }
+            
+            .message-text {
+                font-size: 14px;
+                line-height: 1.5;
+            }
+            
+            /* 로딩 스피너 */
+            .loading-spinner {
+                display: inline-block;
+                width: 20px;
+                height: 20px;
+                border: 3px solid #f3f3f3;
+                border-top: 3px solid #007bff;
+                border-radius: 50%;
+                animation: spin 1s linear infinite;
+                margin-right: 8px;
+            }
+            
+            @keyframes spin {
+                0% { transform: rotate(0deg); }
+                100% { transform: rotate(360deg); }
+            }
+        ]]></style>
+        
+        <script lazy="false" type="text/javascript"><![CDATA[
+            // 팝업 로드 시 실행
+            scwin.onpageload = function() {
+                console.log("이력서 미리보기 팝업 로드");
+                
+                // 부모로부터 전달받은 파라미터 확인
+                var paramData = null;
+                try {
+                    // 여러 방법으로 파라미터 가져오기 시도
+                    if ($p.getParameter && typeof $p.getParameter === 'function') {
+                        paramData = $p.getParameter("paramData");
+                    } 
+                    
+                    if (!paramData && $c.data && $c.data.getParameter) {
+                        paramData = $c.data.getParameter("paramData");
+                    }
+                    
+                    // 부모 윈도우에서 직접 가져오기
+                    if (!paramData && opener && opener.scwin && opener.scwin.paramData) {
+                        paramData = opener.scwin.paramData;
+                    }
+
+                    // 세션 스토리지에서 가져오기
+                    if (!paramData) {
+                        var sessionData = sessionStorage.getItem("resumePreviewParams");
+                        if (sessionData) {
+                            try {
+                                paramData = JSON.parse(sessionData);
+                            } catch (e) {
+                                console.error("세션 데이터 파싱 오류:", e);
+                            }
+                        }
+                    }
+                } catch (e) {
+                    console.error("파라미터 가져오기 오류:", e);
+                }
+                
+                console.log("전달받은 파라미터:", paramData);
+                
+                if (paramData) {
+                    var accountId = paramData.accountId;
+                    var userName = paramData.userName || "사용자";
+                    var resumeFileName = paramData.resumeFileName;
+                    
+                    if (accountId) {
+                        // 데이터맵에 기본 정보 설정
+                        dma_resumeInfo.set("accountId", accountId);
+                        dma_resumeInfo.set("userName", userName);
+                        dma_resumeInfo.set("resumeFileName", resumeFileName);
+                        
+                        // 팝업 타이틀 설정
+                        popup_title.setValue(userName + "의 이력서");
+                        
+                        // 이력서 정보 조회
+                        scwin.loadResumeInfo(accountId);
+                    } else {
+                        scwin.showMessage("오류", "사용자 정보가 올바르지 않습니다.");
+                    }
+                } else {
+                    scwin.showMessage("오류", "전달받은 파라미터가 없습니다.");
+                }
+            };
+            
+            // 이력서 정보 조회
+            scwin.loadResumeInfo = function(userId) {
+                console.log("이력서 정보 조회 시작 - 사용자 ID:", userId);
+                
+                // API URL 설정
+                var apiUrl = "/InsWebApp/USGetResumeInfo.pwkjson?userId=" + userId;
+                console.log("API URL:", apiUrl);
+                
+                // resumeFileName이 이미 있는 경우 그것을 바로 사용
+                var resumeFileName = dma_resumeInfo.get("resumeFileName");
+                if (resumeFileName) {
+                    console.log("이미 가지고 있는 이력서 파일명을 사용:", resumeFileName);
+                    
+                    // 이미 가지고 있는 파일명으로 바로 처리
+                    var mockResponse = {
+                        result: "success",
+                        hasResume: true,
+                        resumeFileName: resumeFileName,
+                        displayName: "이력서.pdf"
+                    };
+                    
+                    // 뷰어 바로 호출
+                    scwin.showPdfViewer(mockResponse);
+                    return;
+                }
+                
+                sbm_getResumeInfo.action = apiUrl;
+                
+                // 로딩 표시
+                scwin.showLoading();
+                
+                // API 호출
+                $c.sbm.execute($p, sbm_getResumeInfo);
+            };
+            
+            // 이력서 정보 조회 완료
+            scwin.sbm_getResumeInfo_submitdone = function(e) {
+                console.log("이력서 정보 조회 완료", e);
+                
+                try {
+                    if (!e || !e.responseJSON) {
+                        scwin.showMessage("오류", "서버 응답 데이터가 없습니다.");
+                        return;
+                    }
+                    
+                    var responseData = e.responseJSON;
+                    console.log("이력서 정보 응답:", responseData);
+                    
+                    // 데이터맵에 설정
+                    var keysToSet = ["result", "hasResume", "resumeFileName", "displayName", "viewUrl", "message"];
+                    for (var i = 0; i < keysToSet.length; i++) {
+                        var key = keysToSet[i];
+                        if (responseData.hasOwnProperty(key)) {
+                            dma_resumeInfo.set(key, responseData[key]);
+                        }
+                    }
+                    
+                    // 이력서 존재 여부에 따른 처리
+                    if (responseData.result === "success" && (responseData.hasResume === true || responseData.resumeFileName)) {
+                        scwin.showPdfViewer(responseData);
+                    } else {
+                        var message = responseData.message || "등록된 이력서가 없습니다.";
+                        scwin.showMessage("이력서 없음", message);
+                    }
+                } catch (err) {
+                    console.error("이력서 정보 처리 중 오류:", err);
+                    scwin.showMessage("오류", "이력서 정보 처리 중 오류가 발생했습니다: " + err.message);
+                }
+            };
+            
+            // 이력서 정보 조회 오류
+            scwin.sbm_getResumeInfo_submiterror = function(e) {
+                console.error("이력서 정보 조회 오류", e);
+                
+                var errorMessage = "이력서 정보 조회 중 오류가 발생했습니다.";
+                
+                if (e.status === 404) {
+                    errorMessage = "이력서 정보를 찾을 수 없습니다.";
+                } else if (e.status === 500) {
+                    errorMessage = "서버 내부 오류가 발생했습니다.";
+                }
+                
+                scwin.showMessage("오류", errorMessage);
+            };
+            
+            // PDF 뷰어 표시
+            scwin.showPdfViewer = function(resumeData) {
+                console.log("PDF 뷰어 표시", resumeData);
+                
+                var viewUrl = resumeData.viewUrl;
+                var resumeFileName = resumeData.resumeFileName;
+                
+                try {
+                    // URL 생성
+                    if (!viewUrl && resumeFileName) {
+                        // 직접 PDF 파일 경로로 접근
+                        if (resumeFileName.toLowerCase().endsWith('.pdf')) {
+                            // 파일명이 직접 PDF 경로인 경우
+                            if (resumeFileName.startsWith('/')) {
+                                // 이미 / 로 시작하는 경우
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                            } else {
+                                // / 로 시작하지 않는 경우
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=/" + encodeURIComponent(resumeFileName);
+                            }
+                        } else {
+                            // API를 통해 접근
+                            viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                        }
+                    }
+                    
+                    if (!viewUrl) {
+                        // 여전히 URL이 없는 경우, userId를 사용해서 파일 경로 생성 시도
+                        var accountId = dma_resumeInfo.get("accountId");
+                        if (accountId) {
+                            viewUrl = "/InsWebApp/USViewResume.pwkjson?userId=" + accountId;
+                        }
+                    }
+                    
+                    if (!viewUrl) {
+                        scwin.showMessage("오류", "PDF 파일 URL을 생성할 수 없습니다.");
+                        return;
+                    }
+                    
+                    if (!viewUrl.startsWith("http") && !viewUrl.startsWith("/")) {
+                        viewUrl = "/" + viewUrl;
+                    }
+                    
+                    if (!viewUrl.startsWith("/InsWebApp/") && !viewUrl.startsWith("http")) {
+                        viewUrl = "/InsWebApp" + viewUrl;
+                    }
+                    
+                    // 현재 페이지의 기본 URL
+                    var baseUrl = window.location.protocol + "//" + window.location.host;
+                    var fullUrl = viewUrl.startsWith("http") ? viewUrl : baseUrl + viewUrl;
+                    
+                    console.log("PDF 뷰어 URL:", fullUrl);
+                    
+                    // iframe에 설정
+                    ifm_pdfViewer.setSrc(fullUrl);
+                    
+                    // PDF 뷰어 영역 표시
+                    pdf_viewer_area.show();
+                    message_area.hide();
+                } catch (error) {
+                    console.error("PDF 뷰어 표시 중 오류:", error);
+                    scwin.showMessage("오류", "PDF 파일을 표시하는 중 오류가 발생했습니다: " + error.message);
+                }
+            };
+            
+            // 메시지 표시
+            scwin.showMessage = function(title, message) {
+                console.log("메시지 표시:", title, message);
+                
+                message_title.setValue(title);
+                message_text.setValue(message);
+                
+                message_area.show();
+                pdf_viewer_area.hide();
+            };
+            
+            // 로딩 표시
+            scwin.showLoading = function() {
+                message_title.setValue("로딩중...");
+                message_text.setValue("이력서 정보를 가져오는 중입니다.");
+                
+                message_area.show();
+                pdf_viewer_area.hide();
+            };
+            
+            // 새 창에서 열기
+            scwin.btn_newWindow_onclick = function() {
+                try {
+                    var viewUrl = dma_resumeInfo.get("viewUrl");
+                    var resumeFileName = dma_resumeInfo.get("resumeFileName");
+                    var accountId = dma_resumeInfo.get("accountId");
+                    
+                    if (!viewUrl && resumeFileName) {
+                        // URL 생성 로직 재활용
+                        if (resumeFileName.toLowerCase().endsWith('.pdf')) {
+                            if (resumeFileName.startsWith('/')) {
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                            } else {
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=/" + encodeURIComponent(resumeFileName);
+                            }
+                        } else {
+                            viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                        }
+                    }
+                    
+                    if (!viewUrl && accountId) {
+                        viewUrl = "/InsWebApp/USViewResume.pwkjson?userId=" + accountId;
+                    }
+                    
+                    if (!viewUrl) {
+                        $c.win.alert("PDF 파일 URL을 생성할 수 없습니다.");
+                        return;
+                    }
+                    
+                    if (!viewUrl.startsWith("http") && !viewUrl.startsWith("/")) {
+                        viewUrl = "/" + viewUrl;
+                    }
+                    
+                    if (!viewUrl.startsWith("/InsWebApp/") && !viewUrl.startsWith("http")) {
+                        viewUrl = "/InsWebApp" + viewUrl;
+                    }
+                    
+                    var baseUrl = window.location.protocol + "//" + window.location.host;
+                    var fullUrl = viewUrl.startsWith("http") ? viewUrl : baseUrl + viewUrl;
+                    
+                    // 새 창으로 열기
+                    window.open(fullUrl, "_blank", "width=800,height=600,scrollbars=yes,resizable=yes");
+                } catch (error) {
+                    console.error("새 창에서 PDF 열기 중 오류:", error);
+                    $c.win.alert("새 창에서 PDF를 열 수 없습니다: " + error.message);
+                }
+            };
+            
+            // 새 탭에서 열기
+            scwin.btn_newTab_onclick = function() {
+                try {
+                    var viewUrl = dma_resumeInfo.get("viewUrl");
+                    var resumeFileName = dma_resumeInfo.get("resumeFileName");
+                    var accountId = dma_resumeInfo.get("accountId");
+                    
+                    if (!viewUrl && resumeFileName) {
+                        // URL 생성 로직 재활용
+                        if (resumeFileName.toLowerCase().endsWith('.pdf')) {
+                            if (resumeFileName.startsWith('/')) {
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                            } else {
+                                viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=/" + encodeURIComponent(resumeFileName);
+                            }
+                        } else {
+                            viewUrl = "/InsWebApp/USViewResume.pwkjson?filePath=" + encodeURIComponent(resumeFileName);
+                        }
+                    }
+                    
+                    if (!viewUrl && accountId) {
+                        viewUrl = "/InsWebApp/USViewResume.pwkjson?userId=" + accountId;
+                    }
+                    
+                    if (!viewUrl) {
+                        $c.win.alert("PDF 파일 URL을 생성할 수 없습니다.");
+                        return;
+                    }
+                    
+                    if (!viewUrl.startsWith("http") && !viewUrl.startsWith("/")) {
+                        viewUrl = "/" + viewUrl;
+                    }
+                    
+                    if (!viewUrl.startsWith("/InsWebApp/") && !viewUrl.startsWith("http")) {
+                        viewUrl = "/InsWebApp" + viewUrl;
+                    }
+                    
+                    var baseUrl = window.location.protocol + "//" + window.location.host;
+                    var fullUrl = viewUrl.startsWith("http") ? viewUrl : baseUrl + viewUrl;
+                    
+                    // 새 탭으로 열기
+                    window.open(fullUrl, "_blank");
+                } catch (error) {
+                    console.error("새 탭에서 PDF 열기 중 오류:", error);
+                    $c.win.alert("새 탭에서 PDF를 열 수 없습니다: " + error.message);
+                }
+            };
+            
+            // 팝업 닫기
+            scwin.btn_close_onclick = function() {
+                $c.win.closePopup();
+            };
+        ]]></script>
+    </head>
+    
+    <body ev:onpageload="scwin.onpageload">
+        <xf:group class="popup-container">
+            <!-- 헤더 영역 -->
+            <xf:group class="popup-header">
+                <w2:textbox id="popup_title" class="popup-title" label="이력서 미리보기"></w2:textbox>
+                <xf:group class="popup-buttons">
+                    <xf:trigger id="btn_newWindow" class="popup-btn btn-new-window" type="button" ev:onclick="scwin.btn_newWindow_onclick">
+                        <xf:label>새창에서 열기</xf:label>
+                    </xf:trigger>
+                    <xf:trigger id="btn_newTab" class="popup-btn btn-new-tab" type="button" ev:onclick="scwin.btn_newTab_onclick">
+                        <xf:label>새탭에서 열기</xf:label>
+                    </xf:trigger>
+                    <xf:trigger id="btn_close" class="popup-btn btn-close" type="button" ev:onclick="scwin.btn_close_onclick">
+                        <xf:label>닫기</xf:label>
+                    </xf:trigger>
+                </xf:group>
+            </xf:group>
+            
+            <!-- PDF 뷰어 영역 -->
+            <xf:group id="pdf_viewer_area" class="pdf-viewer-area" style="display:none;">
+                <w2:iframe id="ifm_pdfViewer" class="pdf-iframe" src=""></w2:iframe>
+            </xf:group>
+            
+            <!-- 메시지 영역 -->
+            <xf:group id="message_area" class="message-area">
+                <w2:textbox id="message_title" class="message-title" label="로딩중..."></w2:textbox>
+                <w2:textbox id="message_text" class="message-text" label="이력서 정보를 가져오는 중입니다."></w2:textbox>
+            </xf:group>
+        </xf:group>
+    </body>
+</html> 

--- a/src/main/webapp/ui/post/ApplicantManagement.xml
+++ b/src/main/webapp/ui/post/ApplicantManagement.xml
@@ -144,6 +144,14 @@
 				color: #666666 !important;
 				cursor: not-allowed !important;
 			}
+			.resume-link-text {
+				color: #007bff; 
+				cursor: pointer; 
+				text-decoration: underline;
+			}
+			.resume-none-text {
+				color: #6c757d;
+			}
 		</style>
 		<xf:model>
 			<w2:dataCollection baseNode="map">
@@ -178,6 +186,12 @@
 		</xf:model>
 		<script lazy="false" type="text/javascript"><![CDATA[
 scwin.onpageload = function () {
+    // window 객체에 customRenderer 함수 등록
+    window.scwin = window.scwin || {};
+    window.scwin.openResumePreview = scwin.openResumePreview;
+    window.scwin.resumeCustomRenderer = scwin.resumeCustomRenderer;
+    window.scwin.displayResumeFileName = scwin.displayResumeFileName;
+
     var jobPostingId = null;
 
     try {
@@ -197,6 +211,14 @@ scwin.onpageload = function () {
     dmp_applicantVo.set("jobPostingId", jobPostingId);
     scwin.updateButtonStates(); // 페이지 로드 시 버튼 상태 초기화
     scwin.search();
+    
+    // 그리드뷰 갱신하기 (customRenderer 적용을 위해)
+    setTimeout(function() {
+        if (gridView) {
+            console.log("지원자 관리 페이지 그리드뷰 새로고침");
+            gridView.refresh();
+        }
+    }, 500);
 };
 
 scwin.search = function () {
@@ -232,11 +254,30 @@ scwin.onPageChange = function (e) {
 };
 
 scwin.onApplicantListLoad = function (e) {
+    console.log("지원자 목록 조회 완료", e);
+    
     if (e.status === 200) {
         var responseData = e.responseJSON;
         if (responseData && responseData.elData) {
             var totalCount = responseData.elData.totalCount;
             pageList1.setTotalRowCount(totalCount);
+            
+            console.log("지원자 상세 데이터:", responseData.elData.applicantDetailVo);
+            
+            // 데이터 로드 후 커스텀 렌더러 재적용
+            setTimeout(function() {
+                console.log("이력서 필드 렌더링 시작");
+                var rows = gridView.getRowCount();
+                console.log("그리드 행 수:", rows);
+                
+                for (var i = 0; i < rows; i++) {
+                    var resumeFileName = dlt_applicantVoList.getCellData(i, "resumeFileName");
+                    console.log("행 " + i + " 이력서 파일명:", resumeFileName);
+                }
+                
+                // 전체 그리드 새로고침
+                gridView.refresh();
+            }, 200);
         }
         // 데이터 로드 후 버튼 상태를 다시 한 번 업데이트할 수 있습니다.
         scwin.updateButtonStates();
@@ -308,6 +349,101 @@ scwin.fail_btn_onclick = function (e) {
         selectedUsers: emailInfoList
     });
 };
+
+// 이력서 필드에 대한 formatter 함수 구현 (customRenderer 대신)
+scwin.displayResumeFileName = function(value) {
+    console.log("displayResumeFileName 호출됨, value:", value);
+    
+    // 이력서 파일명이 있는지 확인
+    var hasResume = value && value.trim() !== "";
+    
+    if (hasResume) {
+        return "<span class='resume-link-text'>이력서 보기</span>";
+    } else {
+        return "<span class='resume-none-text'>이력서 없음</span>";
+    }
+};
+
+// 그리드 셀 클릭 이벤트 (이력서 컬럼)
+scwin.gridView_oncellclick = function(row, col, colId) {
+    console.log("그리드 셀 클릭: row=" + row + ", col=" + col + ", colId=" + colId);
+    
+    if (colId === "resumeFileName") {
+        // 해당 행의 이력서 파일명 확인
+        var resumeFileName = dlt_applicantVoList.getCellData(row, "resumeFileName");
+        
+        // 이력서가 없으면 무시
+        if (!resumeFileName || resumeFileName.trim() === "") {
+            console.log("이력서 파일이 없습니다.");
+            return;
+        }
+        
+        console.log("이력서 미리보기 열기 시도: " + resumeFileName);
+        scwin.openResumePreview(row);
+    }
+};
+
+// 이력서 미리보기 팝업 열기
+scwin.openResumePreview = function(rowIndex) {
+    try {
+        console.log("이력서 미리보기 팝업 열기 - 행 인덱스:", rowIndex);
+        
+        // 선택된 행의 데이터 가져오기
+        var accountId = dlt_applicantVoList.getCellData(rowIndex, "accountId");
+        var userName = dlt_applicantVoList.getCellData(rowIndex, "name");
+        var resumeFileName = dlt_applicantVoList.getCellData(rowIndex, "resumeFileName");
+        
+        console.log("선택된 사용자 정보:", {
+            accountId: accountId,
+            userName: userName,
+            resumeFileName: resumeFileName
+        });
+        
+        // 이력서가 없는 경우
+        if (!resumeFileName || resumeFileName.trim() === "") {
+            $c.win.alert("등록된 이력서가 없습니다.");
+            return;
+        }
+        
+        // 팝업에 전달할 데이터
+        var popupData = {
+            accountId: accountId,
+            userName: userName || "사용자",
+            resumeFileName: resumeFileName
+        };
+        
+        // 전역 변수로 파라미터 저장
+        window.scwin.paramData = popupData;
+        
+        // 세션 스토리지에도 저장
+        try {
+            sessionStorage.setItem("resumePreviewParams", JSON.stringify(popupData));
+        } catch(e) {
+            console.error("세션 스토리지 저장 오류:", e);
+        }
+        
+        // 팝업 옵션
+        var popupOptions = {
+            id: "resume_preview_popup_" + accountId,
+            type: "wframePopup", // pageFramePopup에서 wframePopup으로 변경
+            width: "900px",
+            height: "700px",
+            modal: true,
+            popupName: "이력서 미리보기",
+            resizable: true
+        };
+        
+        console.log("팝업 데이터:", popupData);
+        console.log("팝업 옵션:", popupOptions);
+        
+        // 팝업 열기
+        $c.win.openPopup("../common/ResumePreviewPopup.xml", popupOptions, popupData);
+        
+    } catch (error) {
+        console.error("이력서 미리보기 팝업 열기 중 오류:", error);
+        $c.win.alert("이력서 미리보기를 열 수 없습니다: " + error.message);
+    }
+};
 ]]></script>
 	</head>
 	<body ev:onpageload="scwin.onpageload">
@@ -361,7 +497,7 @@ scwin.fail_btn_onclick = function (e) {
 			<xf:group style="display:flex; flex-direction:column; justify-content:center; align-items:center; padding:20px;">
 				<w2:gridView checkAllType="false" defaultCellHeight="20" id="gridView"
 					style="height:633px;width: 100%;overflow:hidden;box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);border:none;background:#ffffff;"
-					dataList="data:dlt_applicantVoList" readOnly="true" visibleRowNum="10" sortable="true" focusFlow="linear">
+					dataList="data:dlt_applicantVoList" readOnly="true" visibleRowNum="10" sortable="true" focusFlow="linear" ev:oncellclick="scwin.gridView_oncellclick">
 					<w2:caption style="" id="caption2" value="this is a grid caption."></w2:caption>
 					<w2:header style="" id="header2">
 						<w2:row style="" id="row3">
@@ -389,7 +525,7 @@ scwin.fail_btn_onclick = function (e) {
 							<w2:column width="100" inputType="text" style="" id="email" value="" displayMode="label"></w2:column>
 							<w2:column width="80" inputType="text" style="" id="career" value="" displayMode="label"></w2:column>
 							<w2:column width="100" inputType="text" style="" id="currentPosition" value="" displayMode="label"></w2:column>
-							<w2:column width="*" inputType="text" style="" id="resumeFileName" value="" displayMode="label"></w2:column>
+							<w2:column width="150" inputType="text" style="cursor:pointer; color:#007bff;" id="resumeFileName" value="" displayMode="HTML" displayFormatter="scwin.displayResumeFileName"></w2:column>
 							<w2:column width="80" inputType="text" style="" id="typeCode" value="" displayMode="label"></w2:column>
 							<w2:column width="*" inputType="text" style="" id="techStack" value="" displayMode="label"></w2:column>
 							<w2:column width="100" inputType="text" style="" id="applicationStatus" value="" displayMode="label"></w2:column>

--- a/src/main/webapp/ui/post/Scout.xml
+++ b/src/main/webapp/ui/post/Scout.xml
@@ -167,6 +167,14 @@
                 background-color: #6c757d;
                 color: white;
             }
+            .resume-link-text {
+                color: #007bff; 
+                cursor: pointer; 
+                text-decoration: underline;
+            }
+            .resume-none-text {
+                color: #6c757d;
+            }
         </style>
         <xf:model>
             <w2:dataCollection baseNode="map">
@@ -208,11 +216,24 @@
             </xf:submission>
         </xf:model>
         <script lazy="false" type="text/javascript"><![CDATA[scwin.onpageload = function () {
+    // window 객체에 formatter 함수 등록
+    window.scwin = window.scwin || {};
+    window.scwin.openResumePreview = scwin.openResumePreview;
+    window.scwin.displayResumeFileName = scwin.displayResumeFileName;
+    
     // 회사 아이디로 유저 불러오기
     scwin.getJobPostingId();
 
     // 스카웃 상태 필터 기본값 설정
     scoutStatusFilter.setValue("NOT_SCOUTED");
+    
+    // 그리드뷰 갱신하기
+    setTimeout(function() {
+        if (gridView1) {
+            console.log("스카웃 페이지 그리드뷰 새로고침");
+            gridView1.refresh();
+        }
+    }, 500);
 };
 
 // 파라미터로 postId 받기
@@ -359,7 +380,126 @@ scwin.w2selectbox_disabled_onselected = function () {
 };
 
 scwin.sbm_scoutVo_submitdone = function (e) {
+    console.log("스카웃 데이터 조회 완료", e);
+    
+    try {
+        if (e && e.responseJSON && e.responseJSON.elData && e.responseJSON.elData.scoutDetailVo) {
+            var data = e.responseJSON.elData.scoutDetailVo;
+            console.log("스카웃 상세 데이터:", data);
+            
+            // 데이터 로드 후 커스텀 렌더러 재적용
+            setTimeout(function() {
+                console.log("이력서 필드 렌더링 시작");
+                var rows = gridView1.getRowCount();
+                console.log("그리드 행 수:", rows);
+                
+                for (var i = 0; i < rows; i++) {
+                    var resumeFileName = dlt_scoutListVo.getCellData(i, "resumeFileName");
+                    console.log("행 " + i + " 이력서 파일명:", resumeFileName);
+                }
+                
+                // 전체 그리드 새로고침
+                gridView1.refresh();
+            }, 200);
+        }
+    } catch (error) {
+        console.error("스카웃 데이터 처리 중 오류:", error);
+    }
+};
 
+// 이력서 필드에 대한 formatter 함수 구현
+scwin.displayResumeFileName = function(value) {
+    console.log("displayResumeFileName 호출됨, value:", value);
+    
+    // 이력서 파일명이 있는지 확인
+    var hasResume = value && value.trim() !== "";
+    
+    if (hasResume) {
+        return "<span class='resume-link-text'>이력서 보기</span>";
+    } else {
+        return "<span class='resume-none-text'>이력서 없음</span>";
+    }
+};
+
+// 그리드 셀 클릭 이벤트 (이력서 컬럼)
+scwin.gridView1_oncellclick = function(row, col, colId) {
+    console.log("그리드 셀 클릭: row=" + row + ", col=" + col + ", colId=" + colId);
+    
+    if (colId === "resumeFileName") {
+        // 해당 행의 이력서 파일명 확인
+        var resumeFileName = dlt_scoutListVo.getCellData(row, "resumeFileName");
+        
+        // 이력서가 없으면 무시
+        if (!resumeFileName || resumeFileName.trim() === "") {
+            console.log("이력서 파일이 없습니다.");
+            return;
+        }
+        
+        console.log("이력서 미리보기 열기 시도: " + resumeFileName);
+        scwin.openResumePreview(row);
+    }
+};
+
+// 이력서 미리보기 팝업 열기
+scwin.openResumePreview = function(rowIndex) {
+    try {
+        console.log("이력서 미리보기 팝업 열기 - 행 인덱스:", rowIndex);
+        
+        // 선택된 행의 데이터 가져오기
+        var accountId = dlt_scoutListVo.getCellData(rowIndex, "accountId");
+        var userName = dlt_scoutListVo.getCellData(rowIndex, "name");
+        var resumeFileName = dlt_scoutListVo.getCellData(rowIndex, "resumeFileName");
+        
+        console.log("선택된 사용자 정보:", {
+            accountId: accountId,
+            userName: userName,
+            resumeFileName: resumeFileName
+        });
+        
+        // 이력서가 없는 경우
+        if (!resumeFileName || resumeFileName.trim() === "") {
+            $c.win.alert("등록된 이력서가 없습니다.");
+            return;
+        }
+        
+        // 팝업에 전달할 데이터
+        var popupData = {
+            accountId: accountId,
+            userName: userName || "사용자",
+            resumeFileName: resumeFileName
+        };
+        
+        // 전역 변수로 파라미터 저장
+        window.scwin.paramData = popupData;
+        
+        // 세션 스토리지에도 저장
+        try {
+            sessionStorage.setItem("resumePreviewParams", JSON.stringify(popupData));
+        } catch(e) {
+            console.error("세션 스토리지 저장 오류:", e);
+        }
+        
+        // 팝업 옵션
+        var popupOptions = {
+            id: "resume_preview_popup_" + accountId,
+            type: "wframePopup", // pageFramePopup에서 wframePopup으로 변경
+            width: "900px",
+            height: "700px",
+            modal: true,
+            popupName: "이력서 미리보기",
+            resizable: true
+        };
+        
+        console.log("팝업 데이터:", popupData);
+        console.log("팝업 옵션:", popupOptions);
+        
+        // 팝업 열기
+        $c.win.openPopup("../common/ResumePreviewPopup.xml", popupOptions, popupData);
+        
+    } catch (error) {
+        console.error("이력서 미리보기 팝업 열기 중 오류:", error);
+        $c.win.alert("이력서 미리보기를 열 수 없습니다: " + error.message);
+    }
 };
 
 ]]></script>
@@ -462,7 +602,7 @@ scwin.sbm_scoutVo_submitdone = function (e) {
             	<w2:gridView checkAllType="false" dataList="data:dlt_scoutListVo" defaultCellHeight="20" focusFlow="linear"
             		id="gridView1" readOnly="true" sortable="true"
             		style="height:633px;width: 100%;overflow:hidden;box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);border:none;background:#ffffff;"
-            		visibleRowNum="10">
+            		visibleRowNum="10" ev:oncellclick="scwin.gridView1_oncellclick">
             		<w2:caption id="caption2" style="" value="this is a grid caption."></w2:caption>
             		<w2:header id="header2" style="">
             			<w2:row id="row3" style="">
@@ -489,7 +629,7 @@ scwin.sbm_scoutVo_submitdone = function (e) {
             				<w2:column displayMode="label" id="email" inputType="text" style="" value="" width="100"></w2:column>
             				<w2:column displayMode="label" id="career" inputType="text" style="" value="" width="80"></w2:column>
             				<w2:column displayMode="label" id="currentPosition" inputType="text" style="" value="" width="100"></w2:column>
-            				<w2:column displayMode="label" id="resumeFileName" inputType="text" style="" value="" width="*"></w2:column>
+            				<w2:column displayMode="HTML" id="resumeFileName" inputType="text" style="cursor:pointer; color:#007bff;" value="" width="150" displayFormatter="scwin.displayResumeFileName"></w2:column>
             				<w2:column displayMode="label" id="typeCode" inputType="text" style="" value="" width="80"></w2:column>
             				<w2:column displayMode="label" id="techStack" inputType="text" style="" value="" width="*"></w2:column>
             			</w2:row>


### PR DESCRIPTION
## 이력서 PDF 미리보기 기능 개선

### 변경 내용
- `customRenderer` 대신 `displayFormatter`와 `displayMode="HTML"` 사용하여 이력서 필드 표시 문제 해결
- `ResumePreviewPopup.xml` 컴포넌트 추가로 PDF 미리보기 팝업 구현
- CSS 클래스 분리 및 스타일 일관성 개선
- 디버깅 로그 추가

### 해결된 문제
Scout.xml과 ApplicantManagement.xml 페이지에서 이력서 파일명 대신 "이력서 보기"/"이력서 없음" 텍스트가 표시되지 않던 문제를 해결했습니다.

### 테스트 방법
1. Scout 페이지 접속: `/InsWebApp/ui/post/Scout.xml?jobPostingId=1`
2. ApplicantManagement 페이지 접속: `/InsWebApp/ui/post/ApplicantManagement.xml?jobPostingId=1`
3. 이력서 필드에 "이력서 보기"(파란색) 또는 "이력서 없음"(회색) 텍스트 표시 확인
4. "이력서 보기" 클릭 시 PDF 미리보기 팝업 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지원자 및 스카우트 목록에서 이력서 파일명을 클릭하면 이력서 미리보기 팝업이 열리는 기능이 추가되었습니다.
  * 이력서가 없는 경우 "이력서 없음" 안내 문구가 표시됩니다.
  * 이력서 미리보기 팝업에서 PDF를 새 창 또는 새 탭으로 열 수 있습니다.

* **스타일**
  * 이력서 보기 링크 및 안내 문구에 대한 스타일이 개선되었습니다.

* **버그 수정**
  * 그리드 갱신 및 데이터 로딩 후 이력서 미리보기 렌더링이 정상 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->