### PR TITLE
Add multiple location selection with limit of 5

### DIFF
--- a/src/main/webapp/ui/user/LocationSelect.xml
+++ b/src/main/webapp/ui/user/LocationSelect.xml
@@ -86,6 +86,12 @@
                         });
                     }
                 } else {
+                    // 최대 5개까지만 선택 가능하도록 제한
+                    if (selectedLocationsList.length >= 5) {
+                        alert("최대 5개까지만 선택 가능합니다.");
+                        return;
+                    }
+                    
                     selectedLocationsList.push(locationName);
                     var elements = document.querySelectorAll('.location-option');
                     if (elements && elements.length > 0) {
@@ -133,7 +139,7 @@
                     });
                 }
                 
-                countDisplay.textContent = selectedLocationsList.length + ' 개 지역 선택됨';
+                countDisplay.textContent = selectedLocationsList.length + ' 개 지역 선택됨 (최대 5개)';
                 dma_location.set("selectedLocations", selectedLocationsList.join(','));
             };
             

--- a/src/main/webapp/ui/user/updateUser.xml
+++ b/src/main/webapp/ui/user/updateUser.xml
@@ -24,6 +24,13 @@
             		</w2:keyInfo>
             	</w2:dataMap>
 
+                <!-- 선택된 지역 리스트 -->
+                <w2:dataList baseNode="list" id="dlt_selectedLocations" repeatNode="map" saveRemovedData="true" style="">
+                    <w2:columnInfo>
+                        <w2:column dataType="text" id="locationName" name="지역명"></w2:column>
+                    </w2:columnInfo>
+                </w2:dataList>
+
             	<!-- 경력 옵션 -->
             	<w2:dataList id="dlt_careerOptions" baseNode="list" repeatNode="map" saveRemovedData="true">
             		<w2:columnInfo>
@@ -310,9 +317,94 @@
             .remove-tag-btn:hover {
                 color: #d32f2f;
             }
+
+            /* 지역 선택 관련 스타일 */
+            .location-container {
+                width: 100%;
+                margin-top: 10px;
+                border-radius: 8px;
+                border: 1px solid #ddd;
+                padding: 15px;
+                background-color: #f8f9fa;
+            }
+
+            .location-header {
+                display: flex;
+                justify-content: space-between;
+                margin-bottom: 10px;
+                font-size: 14px;
+                color: #666;
+                font-weight: 600;
+            }
+
+            .location-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+                gap: 8px;
+                margin-bottom: 15px;
+            }
+
+            .location-option {
+                padding: 8px 6px;
+                border: 1px solid #e0e0e0;
+                border-radius: 6px;
+                background-color: #ffffff;
+                cursor: pointer;
+                text-align: center;
+                font-size: 14px;
+                transition: all 0.3s ease;
+                color: #333;
+                user-select: none;
+            }
+
+            .location-option:hover {
+                border-color: #007bff;
+                background-color: #f0f8ff;
+                transform: translateY(-1px);
+            }
+
+            .location-option.selected {
+                border-color: #007bff;
+                background-color: #007bff;
+                color: white;
+            }
+
+            .location-tag-container {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+                min-height: 40px;
+            }
+
+            .location-tag {
+                display: flex;
+                align-items: center;
+                background-color: #007bff;
+                color: white;
+                padding: 6px 10px;
+                border-radius: 20px;
+                font-size: 13px;
+                font-weight: 500;
+                gap: 6px;
+            }
+
+            .location-tag-remove {
+                cursor: pointer;
+                font-size: 14px;
+                font-weight: bold;
+                opacity: 0.7;
+                transition: opacity 0.3s ease;
+            }
+
+            .location-tag-remove:hover {
+                opacity: 1;
+            }
         ]]></style>
         
         <script lazy="false" type="text/javascript"><![CDATA[
+// 선택된 지역 배열
+scwin.selectedLocations = [];
+
 scwin.onpageload = function () {
     try {
         // 옵션 데이터 초기화
@@ -453,6 +545,11 @@ scwin.onpageload = function () {
         
         // 파일 업로드를 위한 폼 초기화
         scwin.initResumeUploadForm();
+        
+        // 지역 선택 이벤트 초기화 (DOM이 완전히 로드된 후)
+        setTimeout(function() {
+            scwin.initializeLocationEvents();
+        }, 500);
         
         // 디버깅 정보 추가
         console.log("페이지 로드 완료 - 사용자 ID:", userId);
@@ -678,6 +775,22 @@ scwin.sbm_userDetail_submitdone = function (e) {
 
         if (!dma_userInfoVo.get("bio")) {
             console.log("자기소개 정보가 없습니다.");
+        }
+
+        // 선호 지역 정보 초기화
+        var preferredLocations = dma_userInfoVo.get("preferredLocations");
+        if (preferredLocations) {
+            console.log("선호 지역:", preferredLocations);
+            scwin.selectedLocations = preferredLocations.split(",");
+            // 지역 UI 업데이트
+            setTimeout(function() {
+                scwin.updateLocationDisplay();
+                scwin.highlightSelectedLocations();
+            }, 300);
+        } else {
+            console.log("선호 지역 정보가 없습니다.");
+            scwin.selectedLocations = [];
+            scwin.updateLocationDisplay();
         }
 
     } catch (e) {
@@ -1227,7 +1340,133 @@ scwin.removeTechStack = function (e) {
         dlt_selectTechStacks.removeRow(index);
         scwin.renderSelectedTechStacks(); // UI 업데이트
     }
-};]]></script>
+};
+
+// 지역 선택 토글 함수
+scwin.toggleLocation = function(locationName) {
+    console.log("지역 선택 토글:", locationName);
+    
+    var index = scwin.selectedLocations.indexOf(locationName);
+    
+    if (index > -1) {
+        // 이미 선택된 경우 선택 해제
+        scwin.selectedLocations.splice(index, 1);
+        // UI에서 선택 해제
+        var elements = document.querySelectorAll('.location-option');
+        if (elements && elements.length > 0) {
+            elements.forEach(function(el) {
+                if (el.textContent && el.textContent.trim() === locationName) {
+                    el.classList.remove('selected');
+                }
+            });
+        }
+    } else {
+        // 최대 5개까지만 선택 가능
+        if (scwin.selectedLocations.length >= 5) {
+            alert("최대 5개까지만 선택 가능합니다.");
+            return;
+        }
+        
+        // 선택되지 않은 경우 선택 추가
+        scwin.selectedLocations.push(locationName);
+        // UI에서 선택 표시
+        var elements = document.querySelectorAll('.location-option');
+        if (elements && elements.length > 0) {
+            elements.forEach(function(el) {
+                if (el.textContent && el.textContent.trim() === locationName) {
+                    el.classList.add('selected');
+                }
+            });
+        }
+    }
+    
+    // 선택된 지역 UI와 hidden input 업데이트
+    scwin.updateLocationDisplay();
+};
+
+// 지역 제거 함수
+scwin.removeLocation = function(locationName) {
+    var index = scwin.selectedLocations.indexOf(locationName);
+    if (index > -1) {
+        scwin.selectedLocations.splice(index, 1);
+        
+        // UI에서 선택 해제
+        var elements = document.querySelectorAll('.location-option');
+        if (elements && elements.length > 0) {
+            elements.forEach(function(el) {
+                if (el.textContent && el.textContent.trim() === locationName) {
+                    el.classList.remove('selected');
+                }
+            });
+        }
+        
+        // 선택된 지역 UI와 hidden input 업데이트
+        scwin.updateLocationDisplay();
+    }
+};
+
+// 선택된 지역 표시 업데이트
+scwin.updateLocationDisplay = function() {
+    var container = document.getElementById("selectedLocationTags");
+    var countText = document.getElementById("locationCountText");
+    
+    if (!container || !countText) {
+        console.log("지역 선택 UI 요소를 찾을 수 없습니다.");
+        return;
+    }
+    
+    // 태그 컨테이너 초기화
+    container.innerHTML = '';
+    
+    // 선택된 지역들로 태그 생성
+    if (scwin.selectedLocations && scwin.selectedLocations.length > 0) {
+        scwin.selectedLocations.forEach(function(location) {
+            if (!location) return;
+            
+            var tag = document.createElement('div');
+            tag.className = 'location-tag';
+            tag.innerHTML = location + ' <span class="location-tag-remove" data-location="' + location + '">×</span>';
+            container.appendChild(tag);
+        });
+    }
+    
+    // 선택 개수 표시 업데이트
+    countText.textContent = scwin.selectedLocations.length + "개 선택됨 (최대 5개)";
+    
+    // hidden input 값 업데이트
+    $p.getComponentById("hdn_selectedLocations").setValue(scwin.selectedLocations.join(","));
+    dma_userInfoVo.set("preferredLocations", scwin.selectedLocations.join(","));
+};
+
+// 지역 선택 이벤트 초기화
+scwin.initializeLocationEvents = function() {
+    // 태그 삭제 버튼 이벤트 위임
+    var container = document.getElementById("selectedLocationTags");
+    if (container) {
+        container.addEventListener('click', function(event) {
+            if (event.target && event.target.classList.contains('location-tag-remove')) {
+                var locationName = event.target.getAttribute('data-location');
+                scwin.removeLocation(locationName);
+            }
+        });
+    }
+};
+
+// 선택된 지역 강조 표시
+scwin.highlightSelectedLocations = function() {
+    var options = document.querySelectorAll('.location-option');
+    if (options && options.length > 0) {
+        options.forEach(function(option) {
+            var locationName = option.textContent.trim();
+            if (scwin.selectedLocations.indexOf(locationName) > -1) {
+                option.classList.add('selected');
+            } else {
+                option.classList.remove('selected');
+            }
+        });
+    }
+};
+]]></script>
     </head>
     
     <body ev:onpageload="scwin.onpageload">
@@ -1288,16 +1527,74 @@ scwin.removeTechStack = function (e) {
 
             	<!-- 선호 지역 -->
             	<xf:group class="form-group">
-            		<w2:textbox class="form-label" label="선호 지역"></w2:textbox>
-            		<xf:select1 id="sel_location" ref="data:dma_userInfoVo.preferredLocations" class="form-select" appearance="minimal"
-            			chooseOption="false">
-            			<xf:choices>
-            				<xf:itemset nodeset="data:dlt_locationOptions">
-            					<xf:label ref="label"></xf:label>
-            					<xf:value ref="value"></xf:value>
-            				</xf:itemset>
-            			</xf:choices>
-            		</xf:select1>
+            		<w2:textbox class="form-label" label="선호 지역 (최대 5개)"></w2:textbox>
+            		<!-- 선택된 지역 태그들을 표시할 컨테이너 -->
+            		<xf:group class="location-container">
+            		    <div class="location-header">
+                            <span id="locationCountText">0개 선택됨</span>
+                        </div>
+                        <div class="location-tag-container" id="selectedLocationTags">
+                            <!-- 태그들이 여기에 동적으로 추가됩니다 -->
+                        </div>
+                        <div class="location-grid">
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('서울')">
+                                <xf:label>서울</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('경기')">
+                                <xf:label>경기</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('인천')">
+                                <xf:label>인천</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('부산')">
+                                <xf:label>부산</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('대구')">
+                                <xf:label>대구</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('대전')">
+                                <xf:label>대전</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('광주')">
+                                <xf:label>광주</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('울산')">
+                                <xf:label>울산</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('세종')">
+                                <xf:label>세종</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('강원')">
+                                <xf:label>강원</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('충북')">
+                                <xf:label>충북</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('충남')">
+                                <xf:label>충남</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('전북')">
+                                <xf:label>전북</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('전남')">
+                                <xf:label>전남</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('경북')">
+                                <xf:label>경북</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('경남')">
+                                <xf:label>경남</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('제주')">
+                                <xf:label>제주</xf:label>
+                            </xf:trigger>
+                            <xf:trigger class="location-option" ev:onclick="scwin.toggleLocation('원격근무')">
+                                <xf:label>원격근무</xf:label>
+                            </xf:trigger>
+                        </div>
+                    </xf:group>
+                    <!-- 선택된 지역들을 저장할 히든 인풋 -->
+                    <xf:input style="display:none;" id="hdn_selectedLocations" ref="data:dma_userInfoVo.preferredLocations"></xf:input>
             	</xf:group>
 
             	<!-- 희망연봉 -->


### PR DESCRIPTION
## 선호 지역 다중 선택 기능 구현

### 변경 내용
- 회원가입 시 LocationSelect.xml에서 최대 5개까지 지역 선택 제한 기능 추가
- 개인정보 수정 페이지(updateUser.xml)에서 단일 선택 드롭다운을 다중 선택 UI로 변경
- 선택된 지역을 태그 형태로 표시하고 개별 삭제 기능 추가
- 두 페이지 모두 최대 5개까지만 선택 가능하도록 제한

### 테스트 방법
1. 회원가입 시 지역 선택 페이지에서 5개 초과 선택 시도 → 경고 메시지 확인
2. 개인정보 수정 페이지에서 다중 지역 선택 및 삭제 기능 확인
3. 5개 초과 선택 시도 → 경고 메시지 확인
4. 저장 후 데이터베이스에 정상 저장되는지 확인

### 관련 이슈
- 회원가입 시 다중 지역 선택 가능하지만 개인정보 수정 페이지에서는 단일 선택만 가능했던 불일치 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필 수정 페이지에서 선호 지역을 최대 5개까지 선택할 수 있는 멀티 선택 UI가 추가되었습니다.
  * 선택된 지역이 태그 형태로 표시되며, 태그 클릭 시 개별 삭제가 가능합니다.
  * 선택 가능한 지역 목록이 클릭형 버튼으로 제공되고, 선택 시 스타일이 변경됩니다.
  * 선택 개수와 최대 선택 가능 수가 안내 문구로 표시됩니다.

* **버그 수정**
  * 5개 초과 선택 시 경고 메시지가 표시되고 추가 선택이 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->