### PR TITLE
feat: Standardize login button colors for UI consistency

### DIFF
--- a/src/main/webapp/ui/common/Header.xml
+++ b/src/main/webapp/ui/common/Header.xml
@@ -303,7 +303,7 @@ scwin.txb_login_onclick = function () {
             .btn-main-login {
                 width: 100%;
                 padding: 15px;
-                background-color: #00c73c;
+                background-color: #007bff;
                 color: #fff;
                 border: none;
                 border-radius: 5px;

--- a/src/main/webapp/ui/common/MainPage.xml
+++ b/src/main/webapp/ui/common/MainPage.xml
@@ -446,7 +446,7 @@ scwin.applicationStatus_onclick = function(e) {
                 width: 100%;
                 min-height: 350px;
                 min-width: 400px; /* login-area와 동일한 최소 너비 */
-                background-color: #667eea;
+                background-color: #2196F3;
                 border-radius: 10px;
                 cursor: pointer;
                 text-align: center;
@@ -475,7 +475,7 @@ scwin.applicationStatus_onclick = function(e) {
 
             .ad-button {
                 background-color: #fff;
-                color: #667eea;
+                color: #2196F3;
                 border: none;
                 padding: 15px 40px;
                 border-radius: 30px;
@@ -506,7 +506,7 @@ scwin.applicationStatus_onclick = function(e) {
             .btn-main-login {
                 width: 100%;
                 padding: 15px;
-                background-color: #00c73c;
+                background-color: #007bff;
                 color: #fff;
                 border: none;
                 border-radius: 5px;
@@ -516,7 +516,7 @@ scwin.applicationStatus_onclick = function(e) {
             }
 
             .gift-area {
-                background-color: #f0fff5;
+                background-color: #e3f2fd;
                 padding: 20px;
                 border-radius: 5px;
                 text-align: center;
@@ -524,7 +524,7 @@ scwin.applicationStatus_onclick = function(e) {
 
             .gift-text {
                 font-size: clamp(12px, 1.8vw, 14px);
-                color: #00a832;
+                color: #1976D2;
                 margin-bottom: 5px;
                 display: block;
                 line-height: 1.4;
@@ -532,7 +532,7 @@ scwin.applicationStatus_onclick = function(e) {
 
             .gift-text-bold {
                 font-size: clamp(12px, 1.8vw, 14px);
-                color: #00a832;
+                color: #1976D2;
                 font-weight: bold;
                 margin-bottom: 5px;
                 display: block;
@@ -1145,7 +1145,7 @@ scwin.applicationStatus_onclick = function(e) {
 						<!-- 비로그인 상태 -->
 						<xf:group class="login-area" id="grp_login_area">
 							<w2:textbox class="login-title" label="로그인하고 기업 매칭에 참여해 보세요."></w2:textbox>
-							<xf:trigger class="btn-main-login" id="btnMainLogin" ev:onclick="scwin.btnLogin_onclick" type="button">
+							<xf:trigger class="btn-main-login" id="btnMainLogin" ev:onclick="scwin.btnLogin_onclick" type="button" style="">
 								<xf:label><![CDATA[로그인]]></xf:label>
 							</xf:trigger>
 							<xf:group class="gift-area">


### PR DESCRIPTION
MainPage와 로그인 팝업의 로그인 버튼 색상을 통일하여 일관된 사용자 경험을 제공합니다.

주요 변경사항:
- MainPage.xml 로그인 버튼: 초록색(#00c73c) → 부트스트랩 블루(#007bff)
- 설명 텍스트 영역: 초록색 계열 → 블루 계열로 변경
- ad-area 색상: Material Design 블루로 통일
- Header.xml 로그인 버튼: 팝업과 동일한 색상(#007bff)으로 수정

변경 이유:
- 로그인 팝업의 로그인 버튼과 메인페이지 로그인 버튼 간 색상 불일치 해결
- 전체 UI에서 블루 계열 색상으로 통일하여 브랜드 일관성 향상
- 사용자가 어디서든 동일한 시각적 경험을 할 수 있도록 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 주요 버튼과 영역의 색상 테마가 녹색 및 보라색에서 파란색 계열로 변경되었습니다.
  * 광고 영역, 선물 영역, 버튼 등의 배경색과 텍스트 색상이 파란색 계열로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->